### PR TITLE
Add SetProfile Activity for external use

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,17 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".api.SetProfile"
+            android:autoRemoveFromRecents="true"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:taskAffinity=".api.SetProfile">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
+
         <receiver
             android:name=".widget.ProfileWidget"
             android:exported="true"

--- a/app/src/main/java/com/saiho/togglelineageprofiles/api/SetProfile.java
+++ b/app/src/main/java/com/saiho/togglelineageprofiles/api/SetProfile.java
@@ -1,0 +1,26 @@
+package com.saiho.togglelineageprofiles.api;
+
+import android.app.Activity;
+import android.os.RemoteException;
+
+import static com.saiho.togglelineageprofiles.Common.setCurrentProfile;
+
+public class SetProfile extends Activity {
+
+    public static final String PROFILE_NAME = "com.saiho.togglelineageprofiles.api.profileName";
+
+    protected void onStart() {
+        super.onStart();
+        try {
+            performTask();
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void performTask() throws RemoteException {
+        String profileName = getIntent().getStringExtra( PROFILE_NAME );
+        setCurrentProfile( getApplicationContext(), profileName );
+        finish();
+    }
+}


### PR DESCRIPTION
First of all great thanks to you @saiho for the great app.

I don't know if you find this useful and if the code style fits your needs. But in the case you or someone else finds this useful I've decided to create this PR.

This api.SetProfile activity can be triggered from external app (e.g. Tasker).

Issues #6 (@bbbco) and #7 (@landry314) can then be circumvented by using the activity directly from Tasker and create a widget using this Task in an external widget supporting activites.
So it is possible to change LineageOS profiles programmatically without the need to have a rooted device.

The activity needs to be used as follows:

intent:
android.intent.action.MAIN
package name:
com.saiho.togglelineageprofiles
class name:
com.saiho.togglelineageprofiles.api.SetProfile

extra:
string com.saiho.togglelineageprofiles.api.profileName <Name of the desired profile>


It's tested with LOS 18.1 and 19.1 with E-Robot.